### PR TITLE
Fix orphaned database entries from failed uploads

### DIFF
--- a/app/model/rating_difficulty.go
+++ b/app/model/rating_difficulty.go
@@ -90,3 +90,17 @@ func RatingDifficultyCreate(username, crackmehexid string, rating int) error {
 
 	return standardizeError(err)
 }
+
+// RatingDifficultyDeleteByCrackme deletes all difficulty ratings for a crackme
+func RatingDifficultyDeleteByCrackme(crackmehexid string) error {
+	var err error
+
+	if database.CheckConnection() {
+		collection := database.Mongo.Database(database.ReadConfig().MongoDB.Database).Collection("rating_difficulty")
+		_, err = collection.DeleteMany(database.Ctx, bson.M{"crackmehexid": crackmehexid})
+	} else {
+		err = ErrUnavailable
+	}
+
+	return standardizeError(err)
+}


### PR DESCRIPTION
## Summary

Fixes #30

This PR addresses a critical issue where failed crackme uploads leave orphaned database entries with `visible=false` and no corresponding files.

## Problem

The current upload flow creates database entries **before** writing files:
1. Create DB entry ✅
2. Create ratings ✅  
3. Write file ❌ (if this fails, orphaned entries remain)

This resulted in **204 orphaned entries** in production (2018-2025), with:
- 78 having successful duplicates (users retried)
- 47 having only failed duplicates
- 79 unique failed uploads

## Solution

This PR implements a defensive approach with **3 key changes**:

### 1. Duplicate Check
Prevents users from creating multiple pending submissions with the same name.

### 2. Reversed Order  
Writes file **FIRST**, then creates DB entry. This prevents orphaned DB entries when file writes fail.

### 3. Automatic Cleanup
If anything fails after file creation, the code now cleans up:
- Removes the file
- Deletes the DB entry
- Removes associated ratings

## Changes

### New Model Functions
- `CrackmeCreatePrepare()`: Creates object with pre-generated ID without DB insert
- `CrackmeInsert()`: Inserts a prepared crackme object
- `CrackmeDeleteByHexId()`: Deletes a crackme by hexid
- `RatingDifficultyDeleteByCrackme()`: Deletes ratings for a crackme

### Modified Files
- `app/controller/crackme.go`: Refactored upload flow with duplicate check and cleanup
- `app/model/crackme.go`: Added new prepare/insert/delete functions
- `app/model/rating_difficulty.go`: Added delete function

## Testing Needed

- [ ] Upload a crackme successfully
- [ ] Trigger file write failure and verify cleanup
- [ ] Try uploading duplicate pending submission
- [ ] Verify error messages are user-friendly

## Migration

The existing 203 orphaned entries can be safely removed with a separate cleanup script (not included in this PR).

## Impact

- ✅ Prevents future orphaned entries
- ✅ Better error messages for users
- ✅ Maintains database consistency
- ✅ No breaking changes