### PR TITLE
Display solution and comment counts on crackme page

### DIFF
--- a/app/controller/crackme.go
+++ b/app/controller/crackme.go
@@ -63,6 +63,8 @@ func CrackMeGET(w http.ResponseWriter, r *http.Request) {
     v.Vars["platform"] = crackme.Platform
     v.Vars["solutions"] = solutions
     v.Vars["comments"] = comments
+    v.Vars["nbsolutions"] = crackme.NbSolutions
+    v.Vars["nbcomments"] = crackme.NbComments
     v.Vars["difficulty"] = fmt.Sprintf("%.1f", crackme.Difficulty)
     v.Vars["quality"] = fmt.Sprintf("%.1f", crackme.Quality)
     v.Vars["token"] = csrfbanana.Token(w, r, sess)

--- a/template/crackme/read.tmpl
+++ b/template/crackme/read.tmpl
@@ -62,10 +62,10 @@
         <div class="column col-4" style="margin-bottom:20px;">
             <ul class="tab tab-block" style="border-bottom: .05rem solid transparent;">
                 <li class="tab-item">
-                    <a onclick="changeTab1('solutions', 'comments')">Comments</a>
+                    <a onclick="changeTab1('solutions', 'comments')">Comments ({{.nbcomments}})</a>
                 </li>
                 <li class="tab-item">
-                    <a onclick="changeTab1('comments', 'solutions')">Writeups</a>
+                    <a onclick="changeTab1('comments', 'solutions')">Writeups ({{.nbsolutions}})</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary

Fixes #41 by displaying the number of solutions (writeups) and comments in the tab labels on the crackme detail page.

## Changes Made

### Controller (app/controller/crackme.go):
- Pass `nbsolutions` and `nbcomments` from the crackme object to the template
- These values are already stored in the database (from PR #39)

### Template (template/crackme/read.tmpl):
- Updated tab labels to show counts:
  - "Comments" → "Comments (N)"
  - "Writeups" → "Writeups (N)"

## Before vs After

**Before:**
```
[Comments] [Writeups]
```

**After:**
```
[Comments (5)] [Writeups (3)]
```

## Benefits

- Users can see at a glance how many writeups and comments exist for each crackme
- No need to click through tabs to see if there's any content
- Leverages the counts already stored in the database (efficient, no extra queries)

## Dependencies

This PR depends on PR #39 being merged, which:
- Stores `NbSolutions` and `NbComments` in the database
- Automatically maintains these counts when comments are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)