### PR TITLE
Fix table overflow on search results page

### DIFF
--- a/template/search/search.tmpl
+++ b/template/search/search.tmpl
@@ -123,41 +123,43 @@
                 </select>
             </div>
         </div>
-        <input type="submit" class="btn active float-right" value="Search"> 
+        <input type="submit" class="btn active float-right" value="Search">
         <input type="hidden" id="token" name="token" value="{{.token}}">
     </form>
-    <table class="table table-striped">
-        <thead>
-            <tr style="text-align: center;">
-                <th style="width: 20%;">Name</th>
-                <th style="width: 20%;">Author</th>
-                <th style="width: 9%;">Language</th>
-                <th style="width: 9%;">Arch</th>
-                <th style="width: 4%;">Difficulty</th>
-                <th style="width: 4%;">Quality</th>
-                <th style="width: 9%;">Platform</th>
-                <th style="width: 9%;">Date</th>
-                <th style="width: 4%;">Writeups</th>
-                <th style="width: 4%;">Comments</th>
-            </tr>
-        </thead>
-        <tbody id="content-list">
-            {{range $n := .crackmes}}
-            <tr class="text-center">
-                <td> <a href="/crackme/{{.HexId}}">{{.Name}}</a></td>
-                <td> <a href="/user/{{.Author}}">{{.Author}}</a> </td>
-                <td> {{.Lang}} </td>
-                <td> {{.Arch}} </td>
-                <td> {{printf "%.1f" .Difficulty}} </td>
-                <td> {{printf "%.1f" .Quality}} </td>
-                <td> {{.Platform}} </td>
-                <td> {{.CreatedAt | PRETTYTIME}} </td>
-                <td> {{.NbSolutions}} </td>
-                <td> {{.NbComments}} </td>
-            </tr>
-            {{end}}
-        </tbody>
-    </table>
+    <div style="overflow-x: auto;">
+        <table class="table table-striped">
+            <thead>
+                <tr style="text-align: center;">
+                    <th style="width: 20%;">Name</th>
+                    <th style="width: 20%;">Author</th>
+                    <th style="width: 9%;">Language</th>
+                    <th style="width: 9%;">Arch</th>
+                    <th style="width: 4%;">Difficulty</th>
+                    <th style="width: 4%;">Quality</th>
+                    <th style="width: 9%;">Platform</th>
+                    <th style="width: 9%;">Date</th>
+                    <th style="width: 4%;">Writeups</th>
+                    <th style="width: 4%;">Comments</th>
+                </tr>
+            </thead>
+            <tbody id="content-list">
+                {{range $n := .crackmes}}
+                <tr class="text-center">
+                    <td style="word-break: break-word;"> <a href="/crackme/{{.HexId}}">{{.Name}}</a></td>
+                    <td style="word-break: break-word;"> <a href="/user/{{.Author}}">{{.Author}}</a> </td>
+                    <td> {{.Lang}} </td>
+                    <td> {{.Arch}} </td>
+                    <td> {{printf "%.1f" .Difficulty}} </td>
+                    <td> {{printf "%.1f" .Quality}} </td>
+                    <td> {{.Platform}} </td>
+                    <td> {{.CreatedAt | PRETTYTIME}} </td>
+                    <td> {{.NbSolutions}} </td>
+                    <td> {{.NbComments}} </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
 </div>
 {{template "footer" .}}
 


### PR DESCRIPTION
## Summary
Fixes table overflow issue where search results extend beyond viewport with no horizontal scrollbar.

## Problem
Users reported (#36) that the search results table overflows beyond the viewport when displaying crackmes with lengthy names. This forces users to zoom out to 80% to view all content, particularly affecting:
- Crackme names (Name column)
- Author usernames (Author column)

## Solution
Implemented a two-part fix:

1. **Horizontal scrolling**: Wrapped the table in a `<div>` with `overflow-x: auto` to enable horizontal scrolling when the table exceeds viewport width
2. **Text wrapping**: Added `word-break: break-word` to Name and Author columns to allow long text to wrap within cells

## Benefits
- Users can access all table content at normal zoom levels
- Horizontal scrollbar appears automatically when needed
- Long names wrap gracefully within their columns on wider screens
- Maintains existing table layout and styling
- Works across all viewport sizes and browsers

## Testing
Recommended test scenarios:
- [ ] Search for "Keygen" crackmes with difficulty 1-2 (reproduction case from issue)
- [ ] Verify horizontal scrollbar appears on narrow viewports
- [ ] Verify long crackme names wrap appropriately on wide viewports
- [ ] Test on multiple browsers (Chrome, Firefox, Brave, Safari)
- [ ] Test on mobile devices

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)