### PR TITLE
Add FAQ entry for site content archive

### DIFF
--- a/template/faq/faq.tmpl
+++ b/template/faq/faq.tmpl
@@ -104,6 +104,12 @@
         <p>If you are using more than 99 crackmes for any purpose, please let us know via crackmesone@gmail.com.</p>
         <p>Unauthorized mirroring of the website contents (including the crackmes) is not allowed without explicit permission.</p>
         <div class="divider"></div>
+        <h3 id="archive">Is there an archive of the site's content? <a href="#archive" class="anchor-link">#</a></h3>
+        <p>Yes! We maintain an archive of all crackmes, solutions, and comments from the website. If you wish to use a large amount of the site's content for research, analysis, or educational purposes, <b>please use the archive instead of crawling the site</b>. This helps reduce server load and ensures you get a complete snapshot of the data.</p>
+        <p><b>Archive URL:</b> <a href="https://drive.google.com/file/d/1QA7QbO5z7EAn1A5-B3AoXogJfvPmzzFL/view?usp=sharing" target="_blank">https://drive.google.com/file/d/1QA7QbO5z7EAn1A5-B3AoXogJfvPmzzFL/view?usp=sharing</a></p>
+        <p><b>Archive date:</b> December 21, 2025</p>
+        <p>If you need a more recent archive, please contact us at crackmesone@gmail.com.</p>
+        <div class="divider"></div>
         <h3 id="reset-password">How do I reset my password? <a href="#reset-password" class="anchor-link">#</a></h3>
         <p>If you still remember your password: log in, click "Profile", scroll to the bottom of the page, click "Change Password", and provide your current and new password.</p>
         <p>If you do not remember your current password: please email crackmesone@gmail.com from the email address you used when you registered your account for assistance.</p>


### PR DESCRIPTION
## Summary

Adds a new FAQ entry informing users about the availability of a complete archive of the site's crackmes, solutions, and comments.

## Motivation

- Encourages users who need large amounts of content to use the archive instead of crawling the site
- Reduces server load from web scraping
- Provides researchers and educators with easy access to bulk data
- Makes the archive publicly known and discoverable

## Changes Made

Added new FAQ section "Is there an archive of the site's content?" which includes:
- Explanation that an archive is available
- Clear request to use the archive instead of crawling
- Google Drive download link
- Archive date (December 21, 2025)
- Contact information for requesting more recent archives

## Placement

The new entry is placed after the "Can I use these crackmes as free course material?" section, as they are related topics about using site content in bulk.

## Preview

**Section title:** "Is there an archive of the site's content?"

**Key points:**
- Archive includes all crackmes, solutions, and comments
- Users should use archive instead of crawling for large-scale use
- Archive URL and date provided
- Instructions to contact for updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)