### PR TITLE
Add forgot password link to login page

### DIFF
--- a/template/login/login.tmpl
+++ b/template/login/login.tmpl
@@ -26,6 +26,7 @@
                 <input type="submit" value="Login" class="btn active float-right">
             </form>
             <a href="/register">Register new account</a>
+            <a href="/faq#reset-password" class="float-right">Forgot password?</a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Adds a "Forgot password?" link on the login page
- Links to the existing FAQ section (`/faq#reset-password`) that explains password reset options

Closes #55

## Test plan
- [ ] Navigate to the login page
- [ ] Verify the "Forgot password?" link is displayed
- [ ] Click the link and verify it navigates to the FAQ page at the reset password section

🤖 Generated with [Claude Code](https://claude.com/claude-code)