### PR TITLE
Show all crackmes/solutions/comments on user profile

### DIFF
--- a/app/model/comment.go
+++ b/app/model/comment.go
@@ -57,7 +57,7 @@ func CommentsByUser(name string) ([]Comment, error) {
 	if database.CheckConnection() {
 		collection := database.Mongo.Database(database.ReadConfig().MongoDB.Database).Collection("comment")
 		// Validate the object id
-		opts := options.Find().SetSort(bson.D{{"created_at", -1}}).SetLimit(50)
+		opts := options.Find().SetSort(bson.D{{"created_at", -1}})
 		cursor, err = collection.Find(database.Ctx, bson.M{"author": name, "visible": true}, opts)
 		err = cursor.All(database.Ctx, &result)
 	} else {

--- a/app/model/solution.go
+++ b/app/model/solution.go
@@ -104,7 +104,7 @@ func SolutionsByUser(username string) ([]Solution, error) {
 
 	if database.CheckConnection() {
 		collection := database.Mongo.Database(database.ReadConfig().MongoDB.Database).Collection("solution")
-		opts := options.Find().SetSort(bson.D{{"created_at", -1}}).SetLimit(50)
+		opts := options.Find().SetSort(bson.D{{"created_at", -1}})
 
 		// Validate the object id
 		cursor, err = collection.Find(database.Ctx, bson.M{"author": username, "visible": true}, opts)

--- a/template/user/read.tmpl
+++ b/template/user/read.tmpl
@@ -83,7 +83,7 @@
 
 
         <div class="columns col-12" id="solutions" style="display: none">
-            <h3>Latest writeups</h3>
+            <h3>Writeups</h3>
             <table class="table table-striped">
                 <thead>
                     <tr style="text-align: center;">
@@ -105,7 +105,7 @@
         </div>
 
         <div class="columns col-12 " id="comments" style="display: none">
-            <h3>Latest comments</h3>
+            <h3>Comments</h3>
             <table class="table table-striped">
                 <thead>
                     <tr style="text-align: center;">


### PR DESCRIPTION
## Summary
- Remove the 50-item limit on `SolutionsByUser` and `CommentsByUser` queries
- User profile now displays all crackmes, solutions, and comments instead of just the first 50
- Update template headings from "Latest writeups/comments" to "Writeups/Comments"

Closes #50

## Test plan
- [ ] Navigate to a user profile page with more than 50 solutions or comments
- [ ] Verify all items are displayed, not just the first 50
- [ ] Verify the count shown matches the number of items in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)