### PR TITLE
Add FAQ entry explaining patching and why it's not allowed

### DIFF
--- a/template/faq/faq.tmpl
+++ b/template/faq/faq.tmpl
@@ -69,7 +69,7 @@
         <p>Review the <a href="/upload/writeuprules">writeup submission rules</a>, improve your writeup with detailed explanations, and resubmit. Remember: we want others to learn from your solution!</p>
         <div class="divider"></div>
         <h3 id="what-is-patching">What is patching and why is it not allowed? <a href="#what-is-patching" class="anchor-link">#</a></h3>
-        <p><b>Patching</b> means modifying the binary executable to bypass its protection mechanisms, typically by changing conditional jumps (e.g., replacing <code>JNZ</code> with <code>JZ</code>) or <code>NOP</code>-ing out instructions to skip validation checks entirely.</p>
+        <p><b>Patching</b> means modifying the binary executable to bypass its validation algorithm, typically by changing conditional jumps (e.g., replacing <code>JNZ</code> with <code>JZ</code>) or <code>NOP</code>-ing out instructions to skip validation checks entirely.</p>
         <p>Patching to make the binary print "correct" or "success" is generally <b>not considered a valid solution</b> for crackmes because:</p>
         <ul>
             <li><b>Crackmes are about understanding algorithms:</b> The core purpose of a crackme is to analyze the validation logic and determine the correct input (password, serial key, etc.) that satisfies the check. Patching the final check bypasses this learning entirely.</li>


### PR DESCRIPTION
## Summary
Adds a new FAQ entry that explains:
- **What patching is**: Modifying binaries to bypass protection mechanisms (changing jumps, NOPing instructions)
- **Why it's not considered a valid solution**:
  - Crackmes are about analyzing algorithms and finding correct inputs
  - Patching has limited educational value
  - Writeups should help others learn the algorithm, not just show byte changes
- **Note about reviewer policy**: Even if the crackme author allows patching, reviewers may reject patch-only writeups due to limited contribution

Closes #54

## Test plan
- [ ] Navigate to the FAQ page
- [ ] Verify the new "What is patching and why is it not allowed?" section appears after "Why was my writeup rejected?"
- [ ] Verify the anchor link `#what-is-patching` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)